### PR TITLE
add key_is_before_tag option, add string_keys_utils to be used like a…

### DIFF
--- a/addons/string_keys/csv_writer.gd
+++ b/addons/string_keys/csv_writer.gd
@@ -10,9 +10,12 @@ var write_successful:= false
 var _old_locales: Array
 var _old_keys:= []
 
-func _init(file_path: String, key_tag_seperator: String):
+var _key_is_before_tag:= false
+
+func _init(file_path: String, key_tag_seperator: String, key_is_before_tag: bool):
 	path = file_path
 	tag_seperator = key_tag_seperator
+	_key_is_before_tag = key_is_before_tag
 
 
 func read_old_csv_file():
@@ -43,7 +46,7 @@ func write_keys_to_csv_file(keys: Array, locales: Array, remove_unused: bool):
 	var old_index := 0
 	var new_index := 0
 	while old_index < _old_keys.size() and new_index < keys.size(): #Both left, compare new and old and add in alphabetical order
-		var comparision = _old_keys[old_index][0].casecmp_to(keys[new_index])
+		var comparision = _old_keys[old_index][0].casecmp_to(_key_from_string(keys[new_index]))
 		if comparision == -1: #add next old key
 			if (not keys.has(_old_keys[old_index])) and remove_unused:
 				removed_keys.append(_old_keys[old_index][0])
@@ -51,7 +54,7 @@ func write_keys_to_csv_file(keys: Array, locales: Array, remove_unused: bool):
 				file.store_csv_line(_old_keys[old_index] + _make_filler_strings(_old_keys[old_index].size()))
 			old_index += 1
 		elif comparision == 1: #add next new key
-			file.store_csv_line([keys[new_index], _text_from_key(keys[new_index])] + _make_filler_strings(2))
+			file.store_csv_line([_key_from_string(keys[new_index]), _text_from_key(keys[new_index])] + _make_filler_strings(2))
 			new_index += 1
 		elif comparision == 0: #keys are equal, skip new and use old to keep manual work
 			file.store_csv_line(_old_keys[old_index] + _make_filler_strings(_old_keys[old_index].size()))
@@ -66,7 +69,7 @@ func write_keys_to_csv_file(keys: Array, locales: Array, remove_unused: bool):
 			file.store_csv_line(_old_keys[old_index] + _make_filler_strings(_old_keys[old_index].size()))
 		old_index += 1
 	while new_index < keys.size(): #If only new keys left, add new
-		file.store_csv_line([keys[new_index], _text_from_key(keys[new_index])] + _make_filler_strings(2))
+		file.store_csv_line([_key_from_string(keys[new_index]), _text_from_key(keys[new_index])] + _make_filler_strings(2))
 		new_index += 1
 	file.close()
 	print("StringKeys: Keys saved to .csv file")
@@ -85,6 +88,17 @@ func _make_sure_directory_exists():
 	var dir:= Directory.new()
 	if not dir.dir_exists(path.get_base_dir()):
 		dir.make_dir_recursive(path.get_base_dir())
+
+
+func _key_from_string(key: String) -> String:
+	var tag_index:= key.find(tag_seperator)
+	if tag_index == -1:
+		return key
+	else:
+		if _key_is_before_tag :
+			return key.left(tag_index)
+		else :
+			return key
 
 
 func _text_from_key(key: String) -> String:

--- a/addons/string_keys/string_keys.gd
+++ b/addons/string_keys/string_keys.gd
@@ -31,7 +31,7 @@ func generate_translation_file(options: StringKeysOptions):
 		print("\nStringKeys keys found: ", _keys)
 	
 	if _keys.size() > 0 or options.remove_unused:
-		var csv_writer:= SkCsvWriter.new(options.translation_file, options.tag_seperator)
+		var csv_writer:= SkCsvWriter.new(options.translation_file, options.tag_seperator, options.key_is_before_tag)
 		csv_writer.read_old_csv_file()
 		csv_writer.write_keys_to_csv_file(_keys, options.locales, options.remove_unused)
 		if csv_writer.write_successful:

--- a/addons/string_keys/string_keys_options.gd
+++ b/addons/string_keys/string_keys_options.gd
@@ -6,6 +6,8 @@ export var translation_file:= "res://localization/translations.csv"
 export(Array, String) var patterns_to_search:= ([
 	"tr(\"STR_KEY\")",
 	"Tr(\"STR_KEY\")",
+	"sktr(\"STR_KEY\")",
+	"sk(\"STR_KEY\")",
 	"text = \"STR_KEY\"",
 	"title = \"STR_KEY\"",
 	"hint_tooltip = \"STR_KEY\"",
@@ -28,6 +30,7 @@ export(Array, String) var directories_to_ignore:= ([
 export(Array, String) var locales:= ["en"]
 export var tag_seperator:= "$$"
 export var require_tag:= false
+export var key_is_before_tag:= false
 export var remove_unused:= true setget set_remove_unused
 export var modified_files_only:= false setget set_modified_files_only
 export var print_debug_output:= false

--- a/addons/string_keys/string_keys_utils.gd
+++ b/addons/string_keys/string_keys_utils.gd
@@ -1,0 +1,43 @@
+extends Node
+
+const OPTIONS_DIRECTORY = "res://addons/string_keys/.options"
+const OPTIONS_FILE_PATH = OPTIONS_DIRECTORY + "/string_keys_options.tres"
+
+var _tag_seperator: String
+var _key_is_before_tag: bool
+
+func _init():
+	var options = _get_options()
+	_tag_seperator = options.tag_seperator
+	_key_is_before_tag = options.key_is_before_tag
+
+
+# return the key associated to the string
+func sk(string: String) -> String :
+	return _key_from_string(string)
+
+
+# return the translated string associated with the key within the string
+func sktr(string: String) -> String :
+	return tr(_key_from_string(string))
+
+
+func _get_options() -> StringKeysOptions:
+	if not File.new().file_exists(OPTIONS_FILE_PATH): 
+		var dir:= Directory.new()
+		if not dir.dir_exists(OPTIONS_DIRECTORY):
+			dir.make_dir(OPTIONS_DIRECTORY)
+		ResourceSaver.save(OPTIONS_FILE_PATH, StringKeysOptions.new())
+	var options = load(OPTIONS_FILE_PATH)
+	return options
+
+
+func _key_from_string(key: String) -> String:
+	var tag_index:= key.find(_tag_seperator)
+	if tag_index == -1:
+		return key
+	else:
+		if _key_is_before_tag :
+			return key.left(tag_index)
+		else :
+			return key


### PR DESCRIPTION
…n singleton to take advantage of the new logic
This commit add a new option key_is_before_tag, if is checked the string before the tag ($$ for example) is used in the csv like a key, and the string after the tag is registered like the translated phrase.
for example:
**"start_text$$hey! Is nice to see you again"**
become in the csv:
| key  | en |
| ------------- | ------------- |
| start_text  | hey! Is nice to see you again |

in this way we create clean keys and at the same time we write in code the string for one of the translated languages.
To take advantage of this new functionality I have writen a singleton: string_keys_utils
this singleton have two functions;
```
sk("start_text$$hey! Is nice to see you again") ## return: start_text
sktr("start_text$$hey! Is nice to see you again") ## return: hey! Is nice to see you again
```
where is showed what they return with the csv above.
two news filters are added to take advantage of these two functions.

